### PR TITLE
WI-2005 Bugfix: deselectAll doesn't deselect radion buttons

### DIFF
--- a/dist/js/bootstrap-multiselect.js
+++ b/dist/js/bootstrap-multiselect.js
@@ -1371,20 +1371,20 @@
             var visibleLis = $("li:not(.divider):not(.disabled):not(.multiselect-group):not(.multiselect-filter-hidden):not(.multiselect-collapisble-hidden)", this.$ul).filter(':visible');
 
             if(justVisible) {
-                $('input[type="checkbox"]:enabled' , visibleLis).prop('checked', false);
+                $('input[type="checkbox"]:enabled,input[type="radio"]:enabled' , visibleLis).prop('checked', false);
                 visibleLis.removeClass(this.options.selectedClass);
 
-                $('input[type="checkbox"]:enabled' , visibleLis).each($.proxy(function(index, element) {
+                $('input[type="checkbox"]:enabled,input[type="radio"]:enabled' , visibleLis).each($.proxy(function(index, element) {
                     var value = $(element).val();
                     var option = this.getOptionByValue(value);
                     $(option).prop('selected', false);
                 }, this));
             }
             else {
-                $('input[type="checkbox"]:enabled' , allLis).prop('checked', false);
+                $('input[type="checkbox"]:enabled,input[type="radio"]:enabled' , allLis).prop('checked', false);
                 allLis.removeClass(this.options.selectedClass);
 
-                $('input[type="checkbox"]:enabled' , allLis).each($.proxy(function(index, element) {
+                $('input[type="checkbox"]:enabled,input[type="radio"]:enabled' , allLis).each($.proxy(function(index, element) {
                     var value = $(element).val();
                     var option = this.getOptionByValue(value);
                     $(option).prop('selected', false);

--- a/tests/spec/bootstrap-multiselect.js
+++ b/tests/spec/bootstrap-multiselect.js
@@ -2283,3 +2283,62 @@ describe('Knockout Binding.', function() {
         expect($testArea.next().find('button.multiselect').text().trim()).toEqual('2 selected');
     });
 });
+
+describe('Method "clearSelection" should clear selection in single mode.', function() {
+    beforeEach(function() {
+        var $select = $('<select id="multiselect"></select>');
+        $select.append('<option value="value-1">Option 1</option>');
+        $select.append('<option value="value-2">Option 2</option>');
+        $select.append('<option value="value-3">Option 3</option>');
+
+        $('body').append($select);
+
+        $select.multiselect({
+            buttonContainer: '<div id="multiselect-container"></div>'
+        });
+    });
+
+    it('Method "clearSelection" is able to clear selection.', function() {
+        $('#multiselect-container input[value="value-2"]').click();
+        expect($('#multiselect-container input:checked').length).toBe(1);
+        expect($('#multiselect option:selected').length).toBe(1);
+
+        $('#multiselect').multiselect('clearSelection');
+        expect($('#multiselect-container input:checked').length).toBe(0);
+    });
+
+    afterEach(function() {
+        $('#multiselect').multiselect('destroy');
+        $('#multiselect').remove();
+    });
+});
+describe('Method "clearSelection" should clear selection in multiple mode.', function() {
+    beforeEach(function() {
+        var $select = $('<select id="multiselect" multiple="multiple"></select>');
+        $select.append('<option value="value-1">Option 1</option>');
+        $select.append('<option value="value-2">Option 2</option>');
+        $select.append('<option value="value-3">Option 3</option>');
+
+        $('body').append($select);
+
+        $select.multiselect({
+            buttonContainer: '<div id="multiselect-container"></div>'
+        });
+    });
+
+    it('Method "clearSelection" should clear selection.', function() {
+        $('#multiselect-container input[value="value-1"]').click();
+        $('#multiselect-container input[value="value-2"]').click();
+        expect($('#multiselect-container input:checked').length).toBe(2);
+        expect($('#multiselect option:selected').length).toBe(2);
+
+        $('#multiselect').multiselect('clearSelection');
+        expect($('#multiselect-container input:checked').length).toBe(0);
+        expect($('#multiselect option:selected').length).toBe(0);
+    });
+
+    afterEach(function() {
+        $('#multiselect').multiselect('destroy');
+        $('#multiselect').remove();
+    });
+});


### PR DESCRIPTION
@JesseChezenko-AI : Please have a look

It looks like for some reason the deselectAll method in bootstrap-multiselect does not deselect the option in our single select dropdowns where the options have type radio as opposed to checkbox.
